### PR TITLE
Use two paragraphs instead of a single one with a break line. Adjust CSS

### DIFF
--- a/cwlcon2024-site/assets/main.css
+++ b/cwlcon2024-site/assets/main.css
@@ -78,7 +78,24 @@ th,td{
 /* Website Banner */
 .banner {position: relative; font-family:'Roboto Slab',serif;}
 .top-left {font-size:5.33rem; color: #9b9b9b; background: #ffffff; text-align: center; width: 1000px; height: 67px; position: absolute; padding: 36px 0 0 0; top: 0;}
-.bottom-right {font-size:2.33rem; color: #8a2332; line-height: 1.5rem; width: auto; height: 100px; padding: 0 27px 27px 0; text-align: right; position: absolute; bottom: 0; right: 0; text-shadow: 0 0 0 #000000;}
+.bottom-right {
+    width: auto;
+    height: 100px;
+    padding: 0 27px 27px 0;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+}
+
+.bottom-right p {
+    font-size:2.33rem;
+    color: #8a2332;
+    line-height: 1.5rem;
+    text-shadow: 0 0 0 #000000;
+    text-align: right;
+    margin: 0 0 1rem 0;
+    padding: 0;
+}
 
 /* Conference Title Logo */
 .title1{font-size:1em;color: #B5314C; text-shadow: 1px 1px 3px #c0c0c0;}

--- a/cwlcon2024-site/index.html
+++ b/cwlcon2024-site/index.html
@@ -20,7 +20,8 @@
             <span class="title1">CWL</span><span class="title2">Con</span> <span class="year">2024</span>
         </div>
         <div class="bottom-right">
-            May 15th - May 20th 2024<br> Amsterdam, NL
+            <p>May 15th - May 20th 2024</p>
+            <p>Amsterdam, NL</p>
         </div>
     </div>
 


### PR DESCRIPTION
Closes #18 

Here's Firefox and Chromium rendering the site locally, side by side.

![image](https://github.com/common-workflow-language/cwlcon2024/assets/304786/8cfa7c5d-d131-48f9-99ff-5c3f9b3e011d)

I use mainly Firefox, and changed the default settings for font size and zoom level. That could explain why there other elements render differently, or it could be that there are more things that need to be made more uniform (in which case it might be easier to just add boostrap.css or similar).