### PR TITLE
Header adjustments and some spacing fixes

### DIFF
--- a/cwlcon2024-site/assets/main.css
+++ b/cwlcon2024-site/assets/main.css
@@ -228,7 +228,6 @@ main > article > section > h3 > a:hover:after,
 main > article > section > h4 > a:hover:after{
     content: '\0a\00B6';
     font-weight: normal;
-    font-size: 3vw;
     opacity: 0.8;
 }
 

--- a/cwlcon2024-site/assets/main.css
+++ b/cwlcon2024-site/assets/main.css
@@ -203,15 +203,15 @@ main > article > section > h4 {
 }
 
 main > article > section > h2 {
-    font-size: 3.5vw;
+    font-size: 3vw;
 }
 
 main > article > section > h3 {
-    font-size: 3.0vw;
+    font-size: 2.5vw;
 }
 
 main > article > section > h4 {
-    font-size: 2.5vw;
+    font-size: 2vw;
 }
 
 main > article > section > h1 > a,

--- a/cwlcon2024-site/assets/main.css
+++ b/cwlcon2024-site/assets/main.css
@@ -191,7 +191,7 @@ main > article {
 }
 
 main > article > section {
-    margin: 2rem 0;
+    margin: 4rem 0;
 }
 
 main > article > section > h1,

--- a/cwlcon2024-site/index.html
+++ b/cwlcon2024-site/index.html
@@ -35,7 +35,7 @@
     <nav>
         <ol>
             <li>
-                <a class="current" title="Conference Home Page" href="">Home</a>
+                <a class="current" title="Conference Home Page" href="#home">Home</a>
             </li>
             <li>
                 <a title="Register for the Conference" href="#registration">Registration (TBA)</a>
@@ -57,8 +57,8 @@
 
     <main>
         <article>
-            <section id="introduction">
-                <h2><a href="#introduction">CWLCon 2024</a></h2>
+            <section id="home">
+                <h2><a href="#home">CWLCon 2024</a></h2>
 
                 <p>
                     The 2024 CWL Conference will be the week of May 13!
@@ -71,7 +71,7 @@
             </section>
 
             <section id="call-for-submissions">
-                <h3><a href="#call-for-submissions">Call for Submissions</a></h3>
+                <h4><a href="#call-for-submissions">Call for Submissions</a></h4>
 
                 <p>JOIN US FOR THE 4th ANNUAL CWL CONFERENCE & 10th ANNIVERSARY CELEBRATION</p>
 
@@ -94,7 +94,7 @@
             </section>
 
             <section id="registration">
-                <h2><a href="#registration">Registration</a></h2>
+                <h3><a href="#registration">Registration</a></h3>
 
                 <p>Registrations will open in February 2024 (please check again soon!)</p>
 
@@ -102,7 +102,7 @@
             </section>
 
             <section id="program">
-                <h2><a href="#program">Program</a></h2>
+                <h3><a href="#program">Program</a></h3>
 
                 <p>Please check again soon!</p>
 
@@ -110,7 +110,7 @@
             </section>
 
             <section id="directions">
-                <h2><a href="#directions">Directions</a></h2>
+                <h3><a href="#directions">Directions</a></h3>
 
                 <p>We are yet to find a venue for this conference.</p>
 
@@ -120,7 +120,7 @@
             </section>
 
             <section id="health-and-safety">
-                <h2><a href="#health-and-safety">Health and Safety</a></h2>
+                <h3><a href="#health-and-safety">Health and Safety</a></h3>
 
                 <p>The event has a Health and Safety policy (inspired by <a href="https://publichealthpledge.com">publichealthpledge.com</a>).</p>
 
@@ -139,7 +139,7 @@
             </section>
 
             <section id="code-of-conduct">
-                <h2><a href="#code-of-conduct">Code of Conduct</a></h2>
+                <h3><a href="#code-of-conduct">Code of Conduct</a></h3>
 
                 <p>
                     This event will be held in accordance with the
@@ -166,7 +166,7 @@
             </section>
 
             <section id="organizers">
-                <h2><a href="#organizers">Organizers</a></h2>
+                <h3><a href="#organizers">Organizers</a></h3>
 
                 <ul>
                     <li><a href="https://github.com/mr-c">Michael R. Crusoe</a></li>
@@ -181,7 +181,7 @@
             </section>
 
             <section id="sponsors">
-                <h2><a href="#sponsors">Sponsors</a></h2>
+                <h3><a href="#sponsors">Sponsors</a></h3>
 
                 <p> This could be your organization!! </p>
             </section>
@@ -194,12 +194,11 @@
             <div class="row">
                 <div class="column">
                     <div>
-                        <span><strong>Previous Conference Links</strong></span>
-                        <ul>
-                            <li><a href="https://cwl.discourse.group/t/schedule-of-confirmed-talks/753">CWLCon2023</a></li>
-                            <li><a href="https://cwl.discourse.group/t/2022-cwl-conference-feb-28-mar-4-2022/519">CWLCon2022</a></li>
-                            <li><a href="https://pad.sfconservancy.org/p/CWLcon2021">CWLCon2021</a></li>
-                        </ul>
+                        <span><strong>Previous Conference Links:</strong></span>
+                        <a href="https://cwl.discourse.group/t/schedule-of-confirmed-talks/753">CWLCon2023</a> /
+                        <a href="https://cwl.discourse.group/t/2022-cwl-conference-feb-28-mar-4-2022/519">CWLCon2022</a> /
+                        <a href="https://pad.sfconservancy.org/p/CWLcon2021">CWLCon2021</a>
+
                     </div>
                 </div>
             </div>

--- a/cwlcon2024-site/index.html
+++ b/cwlcon2024-site/index.html
@@ -35,7 +35,7 @@
     <nav>
         <ol>
             <li>
-                <a class="current" title="Conference Home Page" href="#home">Home</a>
+                <a class="current" title="Conference Home Page" href="">Home</a>
             </li>
             <li>
                 <a title="Register for the Conference" href="#registration">Registration (TBA)</a>
@@ -71,7 +71,7 @@
             </section>
 
             <section id="call-for-submissions">
-                <h4><a href="#call-for-submissions">Call for Submissions</a></h4>
+                <h3><a href="#call-for-submissions">Call for Submissions</a></h3>
 
                 <p>JOIN US FOR THE 4th ANNUAL CWL CONFERENCE & 10th ANNIVERSARY CELEBRATION</p>
 
@@ -94,7 +94,7 @@
             </section>
 
             <section id="registration">
-                <h3><a href="#registration">Registration</a></h3>
+                <h2><a href="#registration">Registration</a></h2>
 
                 <p>Registrations will open in February 2024 (please check again soon!)</p>
 
@@ -102,7 +102,7 @@
             </section>
 
             <section id="program">
-                <h3><a href="#program">Program</a></h3>
+                <h2><a href="#program">Program</a></h2>
 
                 <p>Please check again soon!</p>
 
@@ -110,7 +110,7 @@
             </section>
 
             <section id="directions">
-                <h3><a href="#directions">Directions</a></h3>
+                <h2><a href="#directions">Directions</a></h2>
 
                 <p>We are yet to find a venue for this conference.</p>
 
@@ -120,7 +120,7 @@
             </section>
 
             <section id="health-and-safety">
-                <h3><a href="#health-and-safety">Health and Safety</a></h3>
+                <h2><a href="#health-and-safety">Health and Safety</a></h2>
 
                 <p>The event has a Health and Safety policy (inspired by <a href="https://publichealthpledge.com">publichealthpledge.com</a>).</p>
 
@@ -139,7 +139,7 @@
             </section>
 
             <section id="code-of-conduct">
-                <h3><a href="#code-of-conduct">Code of Conduct</a></h3>
+                <h2><a href="#code-of-conduct">Code of Conduct</a></h2>
 
                 <p>
                     This event will be held in accordance with the
@@ -166,7 +166,7 @@
             </section>
 
             <section id="organizers">
-                <h3><a href="#organizers">Organizers</a></h3>
+                <h2><a href="#organizers">Organizers</a></h2>
 
                 <ul>
                     <li><a href="https://github.com/mr-c">Michael R. Crusoe</a></li>
@@ -181,7 +181,7 @@
             </section>
 
             <section id="sponsors">
-                <h3><a href="#sponsors">Sponsors</a></h3>
+                <h2><a href="#sponsors">Sponsors</a></h2>
 
                 <p> This could be your organization!! </p>
             </section>

--- a/cwlcon2024-site/index.html
+++ b/cwlcon2024-site/index.html
@@ -28,7 +28,7 @@
         </div>
         <div>
             <span>Week of May 13th, 2024</span>
-            <span>Amsterdam, NL (and online!)</span>
+            <span>Amsterdam, NL & online!</span>
         </div>
     </header>
 


### PR DESCRIPTION
Drop headers to h3, with 'Call for submissions' to h4 (consider having an 'announcements' section that's h3 and call for submissions goes under that?

Updated section breaks to 4 rem, for small content sections (like project and directions) this looks a little off for now, but those sections will grow.

I like having the previous conference links in the footnotes, but was still in list format on a single line, instead use a '/' to separate each link