### PR TITLE
Update site to show key dates at top

### DIFF
--- a/cwlcon2024-site/index.html
+++ b/cwlcon2024-site/index.html
@@ -29,11 +29,11 @@
                 <a href="">CWLCon 2024</a>
             </h1>
         </div>
-        <!-- This banner is duplicated below for larger viewports. Please update it there as well. -->
-        <div class="banner-text">
-            <span>8th - 17th May 2024</span>
-            <span>Amsterdam, NL & online!</span>
-        </div>
+<!--        &lt;!&ndash; This banner is duplicated below for larger viewports. Please update it there as well. &ndash;&gt;-->
+<!--        <div class="banner-text">-->
+<!--            <span>8th - 17th May 2024</span>-->
+<!--            <span>Amsterdam, NL & online!</span>-->
+<!--        </div>-->
     </header>
 
     <nav>
@@ -75,7 +75,25 @@
             <section id="home">
                 <div class="row">
                     <div class="column">
-                        <h2><a href="#home">CWLCon 2024</a></h2>
+                        <h2><a href="#home">Key Dates</a></h2>
+
+                        <h5><a href="#program-week-1">May 9th - 11th / Online talks in various timezones</a></h5>
+
+                        <br>
+
+                        <h5><a href="#program-week-2">May 14th / In-person training held in Amsterdam, NL</a></h5>
+
+                        <br>
+
+                        <h5><a href="#program-week-2">May 15th - 16th / Hybrid Conference in Amsterdam, NL</a></h5>
+
+                        <br>
+
+                        <h5><a href="#program-week-2">May 17th / Hackathon</a></h5>
+
+                        <br><br>
+
+                        <h2><a href="#home">Conference Summary</a></h2>
 
                         <p>
                             The 2024 CWL Conference will be held in Amsterdam from the Wednesday 15 May to Friday 17 May!<br><br>
@@ -90,7 +108,7 @@
                         </p>
 
                         <p>
-                            <strong>&triangleright;Submissions are open and will close on Friday March 15, 2024 &triangleleft;</strong>
+                            <strong><a href="https://forms.gle/LKCKaNkUWRLj35xL6"> Submissions are open and will close on Friday March 15, 2024 </a></strong>
                         </p>
                     </div>
                     <div class="column">


### PR DESCRIPTION
Provide links to key dates at top of site, resolves #60

Preview:

![image](https://github.com/common-workflow-language/cwlcon2024/assets/8197659/937b1779-04c9-4ebf-adbb-dff65d691f0a)
